### PR TITLE
Feature/string branch names

### DIFF
--- a/ui_new_branch.go
+++ b/ui_new_branch.go
@@ -33,14 +33,17 @@ var (
 
 func makeSafeBranchName(branch string) string {
 
+	// Characters to remove from branch names
 	var illegalChars []string = []string{" ", "\n", "\t"}
 
+	// Loop over the candidate name, trimming or replacing illegal characters as we go
 	for index := 0; index < len(illegalChars); index++ {
 		target := illegalChars[index]
 		branch = strings.Trim(branch, target)
 		branch = strings.ReplaceAll(branch, target, "-")
 	}
 
+	// Convert the whole thing to lower once it's cleaned
 	branch = strings.ToLower(branch)
 
 	return branch

--- a/ui_new_branch.go
+++ b/ui_new_branch.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -30,6 +31,17 @@ var (
 				Background(lipgloss.AdaptiveColor{Light: "#D63B3A", Dark: "#D63B3A"})
 )
 
+func makeSafeBranchName(branch string) string {
+
+	var illegalChars []string = []string{" ", "\n", "\t"}
+
+	for index := 0; index < len(illegalChars); index++ {
+		branch = strings.ReplaceAll(branch, illegalChars[index], "-")
+	}
+
+	return branch
+}
+
 type branchModel struct {
 	branch string
 	done   bool
@@ -37,7 +49,7 @@ type branchModel struct {
 }
 
 func newBranchModel(branch string) branchModel {
-	return branchModel{branch: branch}
+	return branchModel{branch: makeSafeBranchName(branch)}
 }
 
 func (m branchModel) Init() tea.Cmd {

--- a/ui_new_branch.go
+++ b/ui_new_branch.go
@@ -36,8 +36,12 @@ func makeSafeBranchName(branch string) string {
 	var illegalChars []string = []string{" ", "\n", "\t"}
 
 	for index := 0; index < len(illegalChars); index++ {
-		branch = strings.ReplaceAll(branch, illegalChars[index], "-")
+		target := illegalChars[index]
+		branch = strings.Trim(branch, target)
+		branch = strings.ReplaceAll(branch, target, "-")
 	}
+
+	branch = strings.ToLower(branch)
 
 	return branch
 }


### PR DESCRIPTION
Branch names can now be entered as human-readable strings, and will be converted to a suitable name. For example:

```sh
git feature "This is a long
branch name"
```

will give 

`feature/this-is-a-long-branch-name`